### PR TITLE
Issue1: Adding ratings on tile header and on expansion

### DIFF
--- a/client/js/apiKeys.js
+++ b/client/js/apiKeys.js
@@ -1,0 +1,7 @@
+const getApiKeyFromStorage = async () => {
+    return new Promise((resolve) => {
+        chrome.storage.sync.get(LOCAL_STORAGE_API_KEY, (result) =>
+            resolve(result ? result[LOCAL_STORAGE_API_KEY] : '84c24527')
+        );
+    });
+};

--- a/client/js/apiService.js
+++ b/client/js/apiService.js
@@ -1,0 +1,47 @@
+const MOVIE_NOT_FOUND = 'Movie not found!';
+
+const extractRottenTomatoRating = (ratingsArray) => {
+    if (ratingsArray.length > 0) {
+        const rottenTomatoRating = ratingsArray[1]
+            ? ratingsArray[1].value
+            : 'N/A';
+        return rottenTomatoRating;
+    }
+    return 'N/A';
+};
+
+const fetchRatings = async (title) => {
+    // we will add functionality for user to give their keys using popup.html
+    // we can discuss scope. we can do it or it can be added as future scope.
+    let omdbApiKey = await getApiKeyFromStorage() || '84c24527';
+    let defaultRatings = {
+        imdbRating: 'N/A',
+        rottenTomato: 'N/A',
+    };
+    try {
+        const omdbResponse = await fetch(
+            encodeURI(
+                `https://www.omdbapi.com/?apikey=${omdbApiKey}&t=${title}`
+            )
+        );
+
+        const omdbResponseJson = await omdbResponse.json();
+        if (
+            omdbResponseJson['Error'] &&
+            omdbResponseJson['Error'] === MOVIE_NOT_FOUND
+        ) {
+            console.log('OMDB unable to find given movie');
+        } else {
+            defaultRatings = {
+                ...defaultRatings,
+                imdbRating: omdbResponseJson.imdbRating,
+                rottenTomato: extractRottenTomatoRating(
+                    omdbResponseJson.Ratings || []
+                ),
+            };
+        }
+    } catch (error) {
+        console.log(`Failed to fetch rating: ${error}`);
+    }
+    return defaultRatings;
+};

--- a/client/js/appConstants.js
+++ b/client/js/appConstants.js
@@ -1,0 +1,1 @@
+const LOCAL_STORAGE_API_KEY = 'omdb_apikey';

--- a/client/js/content.js
+++ b/client/js/content.js
@@ -1,0 +1,102 @@
+const RATINGS = 'ratings';
+
+function getTitleFromCard(elem) {
+    const title = elem.firstElementChild.innerText;
+    return title || '';
+}
+
+const getRatings = async (title) => {
+    const ratingsInLocalStorage = getRatingsFromLocalStorage(title);
+
+    if (ratingsInLocalStorage) {
+        return ratingsInLocalStorage;
+    }
+
+    const titleRatings = await fetchRatings(title);
+    storeRatingsInLocalStorage(title, titleRatings);
+    return titleRatings;
+};
+
+function storeRatingsInLocalStorage(title, ratings) {
+    if (title && ratings) {
+        let ratingsInStorage = JSON.parse(localStorage.getItem(RATINGS));
+        if (!ratingsInStorage) {
+            ratingsInStorage = {};
+        }
+        ratingsInStorage[title] = ratings;
+        localStorage.setItem(RATINGS, JSON.stringify(ratingsInStorage));
+    }
+}
+
+function getRatingsFromLocalStorage(title) {
+    const ratingsInLocalStorage = JSON.parse(localStorage.getItem(RATINGS));
+    const titleRatings = ratingsInLocalStorage && ratingsInLocalStorage[title];
+    return titleRatings;
+}
+
+const getRatingDivElement = (title, rating) => {
+    const div = document.createElement('div');
+    div.innerHTML = `${title} rating: ${rating}`;
+    return div;
+};
+
+const getInnerHTML = (imdbRating, rottenTomatoRating) => {
+    const innerHTML = `
+    <div>
+    <p style="background-color: red;
+        z-index: 2;
+        margin-top: 0px;
+        position: absolute;
+        top:0; right:0;"
+    >IMDB: ${imdbRating}</p>
+    <p style="background-color: red;
+    z-index: auto;
+    margin-top: 0px;
+    position: absolute;
+    top:0; left:0;"
+>Rotten Tomato: ${rottenTomatoRating}</p>
+    </div>
+    `;
+
+    return innerHTML;
+};
+
+const addRatingsToTile = async (movieTileElement) => {
+    const videoTitle = getTitleFromCard(movieTileElement);
+    const tileParent = document.querySelector(
+        '.previewModal--metadatAndControls-container'
+    );
+    const ratings = await getRatings(videoTitle);
+
+    if (!movieTileElement.hasAttribute('ratings')) {
+        movieTileElement.insertAdjacentHTML(
+            'afterend',
+            getInnerHTML(ratings.imdbRating, ratings.rottenTomato)
+        );
+        movieTileElement.setAttribute('ratings', ratings);
+    }
+
+    if (tileParent) {
+        tileParent.appendChild(getRatingDivElement('IMDB', ratings.imdbRating));
+        tileParent.appendChild(
+            getRatingDivElement('Rotten Tomato', ratings.rottenTomato)
+        );
+    }
+};
+
+const induceDelay = (elem, callback) => {
+    elem.onmouseover = () => {
+        setTimeout(() => callback(elem), 2000);
+    };
+};
+
+const observeChangesInDom = async () => {
+    const netflixAllTitles = document.querySelectorAll('[id^="title-"]');
+    for (title of netflixAllTitles) {
+        const elem = title.firstChild;
+        induceDelay(elem, addRatingsToTile);
+    }
+    setTimeout(observeChangesInDom, 500);
+};
+
+observeChangesInDom();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,19 @@
+{
+    "manifest_version": 2,
+    "name": "Binge",
+    "author": "SE GROUP-7",
+    "version": "1.0",
+    "description": "Extension to get movie ratings",
+    "content_scripts": [
+        {
+            "js": [
+                "client/js/appConstants.js",
+                "client/js/apiKeys.js",
+                "client/js/apiService.js",
+                "client/js/content.js"
+            ],
+            "matches": ["https://www.netflix.com/browse"]
+        }
+    ],
+    "permissions": ["storage", "tabs"]
+}


### PR DESCRIPTION
THIS PR adds below things:

1. added constants file
2. added api service file (mock for now, will be replaced later when backend team works on it and sends their PR)
3. added content.js
4. added manifest.json (we are using chrome storage sync so need permissions to access that)
5. added apiKeys.js file which is to retrieve values from chrome storage

We can discuss about ideas for user to save their own keys. For now, using my own key for testing purposes.

<img width="1431" alt="Screen Shot 2021-09-19 at 1 40 49 PM" src="https://user-images.githubusercontent.com/53666623/133937498-32998e74-8e49-4f21-afcb-0cac185461a8.png">

<img width="1439" alt="Screen Shot 2021-09-19 at 1 41 02 PM" src="https://user-images.githubusercontent.com/53666623/133937501-0259a652-3741-401d-92da-d9debefd623f.png">


I have shown ratings in two ways. We can decide if we want to keep either or both. I personally like on the top header as Eshita anyways will add it to the tile when it will be expanded.